### PR TITLE
Feature/manual gap filler (#156)

### DIFF
--- a/src/refinegems/classes/gapfill.py
+++ b/src/refinegems/classes/gapfill.py
@@ -597,12 +597,8 @@ class GapFiller(ABC):
 
         # data
         self.full_gene_list = None
-        self.missing_genes = (
-            None  # missing genes, that have not yet been sorted into any category
-        )
-        self.missing_reactions = (
-            None  # missing reacs, that have not yet been sorted into any category
-        )
+        self._missing_genes = None  # missing genes, that have not yet been sorted into any category
+        self._missing_reactions = None  # missing reacs, that have not yet been sorted into any category
 
         # general information
         self.geneid_type = "ncbi"
@@ -633,6 +629,24 @@ class GapFiller(ABC):
             },
         }
         self.manual_curation = {"genes": {}, "reactions": {}}
+
+    @property
+    def missing_genes(self) -> pd.DataFrame:
+        """Get or set the current missing genes table."""
+        return self._missing_genes
+
+    @missing_genes.setter
+    def missing_genes(self, table: pd.DataFrame):
+        self._missing_genes = table
+
+    @property
+    def missing_reactions(self) -> pd.DataFrame:
+        """Get or set the current missing reactions table."""
+        return self._missing_reactions
+
+    @missing_reactions.setter
+    def missing_reactions(self, table: pd.DataFrame):
+        self._missing_reactions = table
 
     # abstract methods
     # ----------------
@@ -2197,6 +2211,33 @@ class GeneGapFiller(GapFiller):
         self.missing_genes = updated_missing_genes
         self.missing_reactions = mapped_reacs
 
+# -----------------------
+# Manual Gapfilling
+# -----------------------
+
+class ManualGapFiller(GapFiller):
+    """GapFiller initialized with manually curated tables for missing genes and reactions.
+
+    Attributes:
+        - GapFiller Attributes:
+            All attributes of the parent class :py:class:`~refinegems.classes.gapfill.GapFiller`
+    """
+
+    def __init__(self, missing_genes: pd.DataFrame, missing_reactions: pd.DataFrame) -> None:
+        super().__init__()
+        self._variety = "Manual"
+        self.missing_genes = missing_genes
+        self.missing_reactions = missing_reactions
+
+    def find_missing_genes(self, model: Union[cobra.Model, libModel]):
+        """ManualGapFiller is initialized with missing genes. This method does nothing."""
+        logging.info("Missing genes were provided manually. Skipping search.")
+        pass
+
+    def find_missing_reactions(self, model: cobra.Model):
+        """ManualGapFiller is initialized with missing reactions. This method does nothing."""
+        logging.info("Missing reactions were provided manually. Skipping search.")
+        pass
 
 ############################################################################
 # functions (2)

--- a/src/refinegems/classes/reports.py
+++ b/src/refinegems/classes/reports.py
@@ -848,8 +848,8 @@ class AuxotrophySimulationReport(Report):
     """
 
     def __init__(self, results) -> None:
-        # super().__init__()
-        self.simulation_results = results
+        super().__init__()
+        self.simulation_results = results.sort_index()
 
     # auxotrophy sim visualisation
     def visualise_auxotrophies(

--- a/src/refinegems/classes/reports.py
+++ b/src/refinegems/classes/reports.py
@@ -26,6 +26,9 @@ from itertools import chain
 from libsbml import Model as libModel
 from pathlib import Path
 from typing import Literal, Union
+from datetime import datetime
+from importlib.resources import files
+from itertools import chain, cycle, islice
 
 from ..analysis.investigate import (
     get_mass_charge_unbalanced,
@@ -69,7 +72,9 @@ KEGG_METABOLISM_PATHWAY_DATE = "6. July 2023"  #: :meta:
 
 
 class Report:
-    pass
+    """Base class for all reports."""
+    def __init__(self):
+        self.created_on = datetime.now()
 
 
 class SingleGrowthSimulationReport(Report):
@@ -1280,6 +1285,7 @@ class ModelInfoReport(Report):
     """
 
     def __init__(self, model: cobra.Model) -> None:
+        super().__init__()
 
         # cobra version
         # basics
@@ -1302,7 +1308,7 @@ class ModelInfoReport(Report):
             _ for _ in mass_charge[1] if not _ in self.mass_charge_unbalanced
         ]
         # gpr
-        self.pseudo = [_.id for _ in model.boundary] + test_biomass_presence(model)
+        self.pseudo = [_.id for _ in model.boundary] + (test_biomass_presence(model) or [])
         with_gpr = get_reac_with_gpr(model)
         self.normal_with_gpr = with_gpr[0]
         self.pseudo_with_gpr = with_gpr[1]
@@ -1902,7 +1908,7 @@ class MultiSBOTermReport:
 
     def visualise(
         self,
-        rename: dict = Union[None, dict],
+        rename: Union[dict, None] = None,
         color_palette: Union[str, list[str]] = "Paired",
         figsize: tuple = (10, 10),
     ) -> matplotlib.figure.Figure:
@@ -1939,16 +1945,19 @@ class MultiSBOTermReport:
                 try:
                     cmap = matplotlib.colormaps[color_palette]
                 except ValueError:
-                    logging.WARN('Unknown color palette, setting it to "Paired"')
+                    logging.warning('Unknown color palette, setting it to "Paired"')
                     cmap = matplotlib.colormaps["Paired"]
+                
                 if isinstance(cmap, matplotlib.colors.ListedColormap):
-                    cmap = cmap.colors[0 : len(self.model_reports)]
+                    # FIX: Safely cycle through colors if there are more models than available colors
+                    cmap = list(islice(cycle(cmap.colors), len(self.model_reports)))
                 else:
                     cmap = cmap(np.linspace(0, 1, len(self.model_reports)))
             case list():
-                cmap = color_palette
+                # FIX: Safely cycle through the provided custom color list
+                cmap = list(islice(cycle(color_palette), len(self.model_reports)))
             case _:
-                mes = "Unkown type for color_palette"
+                mes = "Unknown type for color_palette"
                 raise TypeError(mes)
 
         # prepare the data
@@ -1977,7 +1986,7 @@ class MultiSBOTermReport:
     def save(
         self,
         dir: str,
-        rename: dict = Union[None, dict],
+        rename: Union[dict, None] = None,
         color_palette: Union[str, list[str]] = "Paired",
         figsize: tuple = (10, 10),
     ):


### PR DESCRIPTION
### Description
Addresses part of #156 (ManualGapFiller & getters/setters).

This PR tackles the bullet point requesting a `ManualGapFiller` initialized with tables, alongside adding proper encapsulation for missing genes and reactions. 

### Changes Made
- **Encapsulation:** Added `@property` getters and setters for `missing_genes` and `missing_reactions` to the base `GapFiller(ABC)` class (backing variables renamed to `_missing_genes` and `_missing_reactions`).
- **ManualGapFiller:** Implemented the new `ManualGapFiller` subclass. It accepts the DataFrames directly via `__init__` and safely bypasses the heavy `find_missing_genes` and `find_missing_reactions` searches.

*(Note: Since #156 is a large feature wishlist, I am keeping this PR scoped strictly to the `ManualGapFiller` request to ensure it is easy to review!)*