### PR TITLE
feat: draft ModelComparisonReport with dynamic annotation overlap (#209)

### DIFF
--- a/src/refinegems/classes/reports.py
+++ b/src/refinegems/classes/reports.py
@@ -32,6 +32,8 @@ from typing import Literal, Union
 from datetime import datetime
 from importlib.resources import files
 from itertools import chain, cycle, islice
+from upsetplot import from_memberships, UpSet
+from venn import venn
 
 from ..analysis.investigate import (
     get_mass_charge_unbalanced,
@@ -2198,3 +2200,184 @@ class MultiSBOTermReport(Report):
         
         fig = self.visualise(rename, color_palette, figsize)
         fig.savefig(Path(dir, "sboterms.png"), bbox_inches='tight', dpi=400)
+
+
+class ModelComparisonReport(Report):
+    """Report for comparing multiple models based on overall annotation overlap.
+    
+    Dynamically generates Venn diagrams (for <= 4 models) or UpSet plots (for > 4 models)
+    to visualize the intersection of metabolites, reactions, and genes. Entities are matched
+    across models if they share ANY common annotation, ignoring specific namespaces.
+    
+    Attributes:
+        models (list[cobra.Model]): List of models to compare.
+        model_names (list[str]): Names of the models for plotting labels.
+        overlap_data (dict): Dictionary storing the calculated overlap memberships for 
+                             reactions, metabolites, and genes.
+    """
+
+    def __init__(self, models: list[cobra.Model], rename: list[str] = None):
+        super().__init__()
+        self.models = models
+        self.model_names = rename if rename else [m.id for m in models]
+        
+        if len(self.models) != len(self.model_names):
+            raise ValueError("Length of rename list must match number of models.")
+            
+        self.overlap_data = {"reactions": {}, "metabolites": {}, "genes": {}}
+        self._calculate_overlap()
+
+    def _get_flattened_annotations(self, entity) -> set:
+        """Flattens a COBRApy annotation dictionary into a set of 'db:id' strings."""
+        annots = set()
+        for db, ids in entity.annotation.items():
+            if isinstance(ids, list):
+                for i in ids:
+                    annots.add(f"{db}:{i}")
+            elif isinstance(ids, str):
+                annots.add(f"{db}:{ids}")
+        # Always include the internal ID as a fallback for unannotated entities
+        annots.add(f"internal:{entity.id}")
+        return annots
+
+    def _calculate_overlap(self):
+        """Calculates entity overlaps across models using disjoint-set (connected components) logic."""
+        
+        for entity_type in ["reactions", "metabolites", "genes"]:
+            # List of all entities across all models. Each entry: (model_name, entity_object)
+            all_entities = []
+            for model, name in zip(self.models, self.model_names):
+                entities = getattr(model, entity_type)
+                for e in entities:
+                    all_entities.append((name, e))
+            
+            # Map each annotation to the list of entity indices that possess it
+            annotation_to_indices = {}
+            for i, (model_name, entity) in enumerate(all_entities):
+                annots = self._get_flattened_annotations(entity)
+                for ann in annots:
+                    if ann not in annotation_to_indices:
+                        annotation_to_indices[ann] = []
+                    annotation_to_indices[ann].append(i)
+            
+            # Find connected components (entities sharing at least one annotation)
+            visited = set()
+            components = []
+            
+            for i in range(len(all_entities)):
+                if i not in visited:
+                    # BFS to find all connected entities
+                    component = set()
+                    queue = [i]
+                    while queue:
+                        curr = queue.pop(0)
+                        if curr not in visited:
+                            visited.add(curr)
+                            component.add(curr)
+                            # Find neighbors through shared annotations
+                            curr_entity = all_entities[curr][1]
+                            for ann in self._get_flattened_annotations(curr_entity):
+                                for neighbor in annotation_to_indices[ann]:
+                                    if neighbor not in visited:
+                                        queue.append(neighbor)
+                    components.append(component)
+                    
+            # Map components to model memberships for UpSet/Venn plotting
+            # For each unique entity (component), which models contain it?
+            memberships = []
+            for comp in components:
+                models_in_comp = set([all_entities[idx][0] for idx in comp])
+                memberships.append(list(models_in_comp))
+                
+            self.overlap_data[entity_type] = memberships
+
+    def visualise(self, entity_type: Literal["reactions", "metabolites", "genes"] = "reactions", 
+                  cmap: Union[list[tuple], None] = None, upset_min_subset_size: int = 15, **kwargs) -> matplotlib.figure.Figure:
+        """Visualise the model comparison.
+        
+        Dynamically routes to a Venn diagram (<= 4 models) or an UpSet plot (> 4 models).
+        
+        Args:
+            entity_type: The type of entity to visualize. Defaults to "reactions".
+            cmap: Optional color map.
+            upset_min_subset_size: Minimum subset size for UpSet plot.
+            **kwargs: Additional plotting arguments.
+            
+        Returns:
+            matplotlib.figure.Figure: The generated plot.
+        """
+        memberships = self.overlap_data[entity_type]
+        
+        if len(self.models) <= 4:
+            return self._plot_venn(memberships, entity_type, cmap, **kwargs)
+        else:
+            return self._plot_upset(memberships, entity_type, cmap, upset_min_subset_size, **kwargs)
+
+    def _plot_venn(self, memberships: list, entity_type: str, cmap, **kwargs):
+        """Helper to generate a Venn diagram (<= 4 models)."""
+        # Convert memberships to the dictionary format expected by the venn library
+        model2ids = {name: set() for name in self.model_names}
+        for i, models_present in enumerate(memberships):
+            for model_name in models_present:
+                model2ids[model_name].add(f"entity_{i}")
+                
+        venn_kwargs = kwargs.get('venn_kwargs', {'fmt': "{percentage:.1f}%", 'legend_loc': 'lower right'})
+        
+        # venn() returns an Axes object, not a Figure
+        ax = venn(model2ids, cmap=cmap, **venn_kwargs)
+        ax.set_title(f"Annotation Overlap: {entity_type.capitalize()}")
+        
+        # Extract and return the parent figure to keep return types consistent
+        return ax.get_figure()
+
+    def _plot_upset(self, memberships: list, entity_type: str, cmap, min_subset_size: int, **kwargs):
+        """Helper to generate an UpSet plot (> 4 models)."""
+        from collections import Counter
+        
+        # Pre-aggregate memberships to avoid upsetplot/pandas duplicate index bugs
+        membership_tuples = [tuple(sorted(m)) for m in memberships]
+        counts = Counter(membership_tuples)
+        
+        unique_memberships = list(counts.keys())
+        data_counts = list(counts.values())
+        
+        upset_data = from_memberships(unique_memberships, data=data_counts)
+        fig = plt.figure()
+        
+        # Set show_counts=False to bypass the pandas >= 2.2.0 matplotlib plotting bug
+        upset = UpSet(upset_data, subset_size='sum', min_subset_size=min_subset_size, show_counts=False)
+        
+        if cmap:
+            max_degree = max(len(idx) for idx in upset_data.index)
+            for degree in range(1, max_degree + 1):
+                colour = cmap[(degree - 1) % len(cmap)]
+                upset.style_subsets(min_degree=degree, facecolor=colour)
+
+        plot_res = upset.plot(fig=fig)
+        plot_res["intersections"].set_ylabel("Subset size")
+        plot_res["totals"].set_xlabel("Total Entity amount")
+        fig.suptitle(f"Annotation Overlap: {entity_type.capitalize()}", fontsize=14)
+        return fig
+
+    def to_table(self) -> pd.DataFrame:
+        """Return a summary table of the overlap statistics."""
+        # @TODO: Format self.overlap_data into a pandas DataFrame based on exact requirements
+        pass
+
+    def save(self, dir: Union[str, Path], **kwargs):
+        """Save the comparison report tables and plots to the specified directory."""
+        super().save(dir)
+        
+        dir_path = Path(dir) / "ModelComparisonReport"
+        dir_path.mkdir(parents=True, exist_ok=True)
+        
+        for entity_type in ["reactions", "metabolites", "genes"]:
+            fig = self.visualise(entity_type=entity_type, **kwargs)
+            fig.savefig(dir_path / f"{entity_type}_overlap.png", bbox_inches="tight", dpi=300)
+            plt.close(fig)
+            
+    def __str__(self):
+        return f"ModelComparisonReport comparing {len(self.models)} models: {', '.join(self.model_names)}."
+        
+    def to_dict(self) -> dict:
+        return self.overlap_data


### PR DESCRIPTION
### Description
Addresses #209

This is a Draft PR to share the initial skeleton and core logic for the new `ModelComparisonReport` class, incorporating the expanded scope discussed in the issue. I am opening this early to get feedback on the overlap algorithm and plotting behavior before finalizing the data export methods.

### Changes Made
*   **Added `ModelComparisonReport`**: Created the new report class inside `src/refinegems/classes/reports.py`.
*   **Overall Annotation Overlap**: Implemented a connected-components (BFS) algorithm in `_calculate_overlap()` that flattens COBRApy annotations. Entities are now matched across models if they share *any* common annotation string, completely ignoring specific namespaces.
*   **Dynamic Plotting Router**: Implemented `visualise()` to automatically route to `venn` (for $\le 4$ models) or `upsetplot` (for $> 4$ models).
*   **Bug Workaround**: In `_plot_upset`, I pre-aggregated the memberships using Python's `Counter` and set `show_counts=False`. This safely bypasses a known `TypeError` crash caused by an incompatibility between `upsetplot` and `pandas >= 2.2.0`.

### Questions for Reviewers
1. Does the connected-components approach for the overall annotation overlap align with what you envisioned for Release 2.0?
2. Are you comfortable leaving `show_counts=False` on the UpSet plots to ensure compatibility with newer pandas versions, or would you prefer a different workaround?

Once the core logic is approved, I will finalize the `to_table()` and `save()` methods.